### PR TITLE
Avoid filtering by single-valued enum fields

### DIFF
--- a/app/scripts/controllers/report_ctrl.coffee
+++ b/app/scripts/controllers/report_ctrl.coffee
@@ -61,7 +61,9 @@ angular.module('ndApp')
           [$scope.currentReport, currentReportVersion] = ReportsService.deserialize(reportData, fieldsCollection)
           $scope.fieldsInfo =
             fields: fieldsCollection.all()
+            filterFields: fieldsCollection.filterFields()
             enumFields: fieldsCollection.allEnum()
+            multiValuedEnumFields: fieldsCollection.multiValuedEnums()
             datePeriods: fieldsCollection.datePeriods()
 
           $scope.$watch 'currentReport', debounce(saveCurrentReport, 300), true

--- a/app/scripts/models/fields_collection.coffee
+++ b/app/scripts/models/fields_collection.coffee
@@ -27,6 +27,13 @@ class @FieldsCollection
   find: (name) ->
     @fields[name]
 
+  filterFields: ->
+    filtereableFields = _.reject @fields, (field) -> field.type == 'enum' && field.options.length <= 1
+    _.sortBy filtereableFields, (f) -> f.label.toLowerCase()
+
+  multiValuedEnums: ->
+    _.filter @allEnum(), (field) -> field.options.length > 1
+
   optionsFor: (name) ->
     @fields[name].options
 

--- a/app/views/charts/TrendlineConfig.html
+++ b/app/views/charts/TrendlineConfig.html
@@ -11,7 +11,7 @@
       <input type="radio" name="display" ng-model="chart.display" value="split"> Split by
     </label>
     <select ng-disabled="chart.display != 'split'" ng-model="chart.splitField">
-      <option ng-repeat="enumField in fieldsInfo.enumFields" value="{{enumField.name}}">{{enumField.label}}</option>
+      <option ng-repeat="enumField in fieldsInfo.multiValuedEnumFields" value="{{enumField.name}}">{{enumField.label}}</option>
     </select>
     <span ng-show="hasAnyParentLocations()">
       <br/>

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -54,7 +54,7 @@
       <div class="add-new-filter">
         <a href="javascript:void(0);" ng-click="addNewFilterIsCollapsed = !addNewFilterIsCollapsed"><span>+</span> Add new filter</a>
         <div collapse="addNewFilterIsCollapsed">
-          <a title="{{field.label}}" ng-repeat="field in fieldsInfo.fields" href="javascript:void(0);" ng-click="addFilter(field)">
+          <a title="{{field.label}}" ng-repeat="field in fieldsInfo.filterFields" href="javascript:void(0);" ng-click="addFilter(field)">
             <i ng-class="[field.name, field.type]"></i>
             <span>{{field.label}}</span>
           </a>


### PR DESCRIPTION
Don't show a field filter - nor a Split by option in the trendline graph - for enum fields that have a single value, as they won't filter anything.

Names could be better, maybe.
