### PR TITLE
fix issues related to resource change in new report control

### DIFF
--- a/app/scripts/controllers/new_report_ctrl.coffee
+++ b/app/scripts/controllers/new_report_ctrl.coffee
@@ -17,8 +17,12 @@ angular.module('ndApp')
           $scope.options = mainField.options
           $scope.report = new Report(fieldsCollection, $scope.resource)
           $scope.report.mainField = mainField.name
-          $scope.report.mainValue = $scope.options[0].value
+          # $scope.report.mainOption property is not persisted.
+          # It is added to set the selected value in a friendly ng-options way
+          # and $scope.report.mainValue is in sync with it.
+          $scope.report.mainOption = $scope.options[0]
           $scope.events = "..."
+          computeCount()
 
       computeCount = ->
         return if not $scope.report
@@ -35,4 +39,7 @@ angular.module('ndApp')
 
       $scope.$watch 'resource', resourceSelected
       $scope.$watch 'report.mainValue', computeCount
+      $scope.$watch 'report.mainOption', ->
+        $scope.report.mainValue = $scope.report.mainOption.value
+
 

--- a/app/views/reports/new.html
+++ b/app/views/reports/new.html
@@ -26,9 +26,7 @@
       <div>
         <label for="mainValue">{{mainLabel}}</label>
         <br/>
-        <select id="mainValue" ng-model="report.mainValue">
-          <option ng-repeat="option in options" value="{{option.value}}">{{option.label}}</option>
-        </select>
+        <select id="mainValue" ng-model="report.mainOption" ng-options="option.label for option in options" />
         (Events: {{events}})
       </div>
       <br/>


### PR DESCRIPTION
- force reload of event count when the resource type is changed
- use ng-options to properly set the selected option upon options are changed due to a resource change.
  - before this the condition (mainOption) was showing an empty option that after changing it, it dissappear.
- a mainOption property that is not persisted is added to set the selected value in a friendly ng-options way
