### PR TITLE
Fix assay value in report context.

### DIFF
--- a/app/scripts/services/local_reports_service.coffee
+++ b/app/scripts/services/local_reports_service.coffee
@@ -57,7 +57,7 @@ angular.module('ndApp').service 'LocalReportsService', (localStorageService, set
 
     getContext: (data) ->
       context = {}
-      context[data.mainField] = data.mainValue
+      context[data.mainField] = data.mainValue.value
       context
 
     deserialize: (data, fieldsCollection) ->

--- a/app/scripts/services/remote_reports_service.coffee
+++ b/app/scripts/services/remote_reports_service.coffee
@@ -61,7 +61,7 @@ angular.module('ndApp').service 'RemoteReportsService', (KeyValueStore, FiltersS
     getContext: (data) ->
       parsed = JSON.parse(data.value)
       context = {}
-      context[parsed.mainField] = parsed.mainValue
+      context[parsed.mainField] = parsed.mainValue.value
       context
 
     deserialize: (reportData, fieldsCollection) ->


### PR DESCRIPTION
(Fixes instedd/cepheid-web#1002)

When retrieving building the context for a particular report, to get the
available filters, the assay value was being handled incorrectly.
Report's `mainValue` now contains a dictionary with the assay label,
value, etc.. Use the value part for setting the context.
